### PR TITLE
fix: rowとcolumnの変数名の命名が逆だった

### DIFF
--- a/components/BingoSheet.tsx
+++ b/components/BingoSheet.tsx
@@ -4,14 +4,14 @@ import { useBingo } from '../features/bingoHooks';
 import { BINGO_SIZE } from '../features/config';
 import { BingoElement } from './BingoElement';
 
-type BingoRowProps = {
-  rowNameList: string[];
+type BingoColumnProps = {
+  columnNameList: string[];
 };
 
-const BingoRowComponent: FC<BingoRowProps> = ({ rowNameList }) => {
+const BingoColumnComponent: FC<BingoColumnProps> = ({ columnNameList }) => {
   return (
     <Grid gap={2} pt={2} px={4} templateColumns="repeat(5,1fr)">
-      {rowNameList.map((el, i) => {
+      {columnNameList.map((el, i) => {
         return (
           <Text
             color="primary"
@@ -27,14 +27,14 @@ const BingoRowComponent: FC<BingoRowProps> = ({ rowNameList }) => {
   );
 };
 
-const BingoRow = memo(BingoRowComponent);
+const BingoColumn = memo(BingoColumnComponent);
 
 export const BingoSheet: FC<{}> = () => {
   const [bingoSheet, bingoLineState, openBingo] = useBingo(BINGO_SIZE);
-  const rowNameList = useMemo(() => ['B', 'I', 'N', 'G', 'O'], []);
+  const columnNameList = useMemo(() => ['B', 'I', 'N', 'G', 'O'], []);
   return (
     <>
-      <BingoRow rowNameList={rowNameList} />
+      <BingoColumn columnNameList={columnNameList} />
       <Grid
         gap={2}
         gridAutoFlow="column"
@@ -43,15 +43,15 @@ export const BingoSheet: FC<{}> = () => {
         templateColumns="repeat(5,1fr)"
         templateRows="repeat(5,1fr)"
       >
-        {bingoSheet?.map((row, i) => {
-          return row.map((el, j) => {
+        {bingoSheet?.map((column, i) => {
+          return column.map((el, j) => {
             return (
               <BingoElement
                 bingoLineState={bingoLineState}
                 elementInfo={el}
                 key={String(i) + String(j)}
                 open={openBingo}
-                position={{ rowNum: i, columnNum: j }}
+                position={{ columnNum: i, rowNum: j }}
               />
             );
           });

--- a/features/bingo.d.ts
+++ b/features/bingo.d.ts
@@ -1,4 +1,4 @@
-export type BingoElementPosition = { rowNum: number; columnNum: number };
+export type BingoElementPosition = { columnNum: number; rowNum: number };
 
 export type BingoElementInfo = { num: number; isOpened: boolean };
 

--- a/features/bingoHooks.test.ts
+++ b/features/bingoHooks.test.ts
@@ -17,8 +17,8 @@ describe(useBingo.name, () => {
 
   test('Line判定用のStateが初期状態である。', () => {
     expect(result.current[1]).toEqual({
-      row: ['Initial', 'Initial', 'Initial', 'Initial', 'Initial'],
       column: ['Initial', 'Initial', 'Initial', 'Initial', 'Initial'],
+      row: ['Initial', 'Initial', 'Initial', 'Initial', 'Initial'],
       upper: 'Initial',
       lower: 'Initial',
     });
@@ -27,26 +27,27 @@ describe(useBingo.name, () => {
   test('ビンゴを空けられる。', async () => {
     await act(async () => {
       Promise.all([
-        result.current[2]({ rowNum: 0, columnNum: 0 }),
-        result.current[2]({ rowNum: 0, columnNum: 1 }),
-        result.current[2]({ rowNum: 0, columnNum: 2 }),
-        result.current[2]({ rowNum: 1, columnNum: 0 }),
-        result.current[2]({ rowNum: 1, columnNum: 1 }),
-        result.current[2]({ rowNum: 1, columnNum: 2 }),
-        result.current[2]({ rowNum: 1, columnNum: 3 }),
-        result.current[2]({ rowNum: 2, columnNum: 0 }),
-        result.current[2]({ rowNum: 2, columnNum: 1 }),
-        result.current[2]({ rowNum: 2, columnNum: 3 }),
-        result.current[2]({ rowNum: 2, columnNum: 4 }),
-        result.current[2]({ rowNum: 3, columnNum: 0 }),
-        result.current[2]({ rowNum: 3, columnNum: 1 }),
-        result.current[2]({ rowNum: 3, columnNum: 3 }),
-        result.current[2]({ rowNum: 4, columnNum: 0 }),
-        result.current[2]({ rowNum: 4, columnNum: 1 }),
-        result.current[2]({ rowNum: 4, columnNum: 3 }),
-        result.current[2]({ rowNum: 4, columnNum: 4 }),
+        result.current[2]({ columnNum: 0, rowNum: 0 }),
+        result.current[2]({ columnNum: 0, rowNum: 1 }),
+        result.current[2]({ columnNum: 0, rowNum: 2 }),
+        result.current[2]({ columnNum: 1, rowNum: 0 }),
+        result.current[2]({ columnNum: 1, rowNum: 1 }),
+        result.current[2]({ columnNum: 1, rowNum: 2 }),
+        result.current[2]({ columnNum: 1, rowNum: 3 }),
+        result.current[2]({ columnNum: 2, rowNum: 0 }),
+        result.current[2]({ columnNum: 2, rowNum: 1 }),
+        result.current[2]({ columnNum: 2, rowNum: 3 }),
+        result.current[2]({ columnNum: 2, rowNum: 4 }),
+        result.current[2]({ columnNum: 3, rowNum: 0 }),
+        result.current[2]({ columnNum: 3, rowNum: 1 }),
+        result.current[2]({ columnNum: 3, rowNum: 3 }),
+        result.current[2]({ columnNum: 4, rowNum: 0 }),
+        result.current[2]({ columnNum: 4, rowNum: 1 }),
+        result.current[2]({ columnNum: 4, rowNum: 3 }),
+        result.current[2]({ columnNum: 4, rowNum: 4 }),
       ]);
     });
+    console.log(result.current[0]);
     expect(result.current[0]?.flat().map((el) => el.isOpened)).toEqual([
       true,
       true,
@@ -76,8 +77,8 @@ describe(useBingo.name, () => {
     ]);
 
     expect(result.current[1]).toEqual({
-      row: ['Initial', 'Reach', 'Bingo', 'Initial', 'Reach'],
-      column: ['Bingo', 'Bingo', 'Initial', 'Reach', 'Initial'],
+      column: ['Initial', 'Reach', 'Bingo', 'Initial', 'Reach'],
+      row: ['Bingo', 'Bingo', 'Initial', 'Reach', 'Initial'],
       upper: 'Reach',
       lower: 'Bingo',
     });

--- a/features/bingoHooks.test.ts
+++ b/features/bingoHooks.test.ts
@@ -47,7 +47,6 @@ describe(useBingo.name, () => {
         result.current[2]({ columnNum: 4, rowNum: 4 }),
       ]);
     });
-    console.log(result.current[0]);
     expect(result.current[0]?.flat().map((el) => el.isOpened)).toEqual([
       true,
       true,

--- a/features/bingoHooks.ts
+++ b/features/bingoHooks.ts
@@ -21,7 +21,6 @@ export const useBingo = (length: number) => {
 
       const newBingoSheet = [...bingoSheet];
       newBingoSheet[position.columnNum][position.rowNum].isOpened = true;
-      console.log(newBingoSheet);
       setBingoSheet(newBingoSheet);
 
       setBingoLineState((preState) => {

--- a/features/bingoHooks.ts
+++ b/features/bingoHooks.ts
@@ -9,8 +9,8 @@ export const useBingo = (length: number) => {
   );
 
   const [bingoLineState, setBingoLineState] = useState<BingoLineState>({
-    row: Array.from({ length }).map(() => 'Initial'),
     column: Array.from({ length }).map(() => 'Initial'),
+    row: Array.from({ length }).map(() => 'Initial'),
     upper: 'Initial',
     lower: 'Initial',
   });
@@ -20,17 +20,18 @@ export const useBingo = (length: number) => {
       if (!bingoSheet) return;
 
       const newBingoSheet = [...bingoSheet];
-      newBingoSheet[position.rowNum][position.columnNum].isOpened = true;
+      newBingoSheet[position.columnNum][position.rowNum].isOpened = true;
+      console.log(newBingoSheet);
       setBingoSheet(newBingoSheet);
 
       setBingoLineState((preState) => {
-        const { row, column, upper, lower } = getLineStatus(
+        const { column, row, upper, lower } = getLineStatus(
           position,
           newBingoSheet,
         );
         const newState = { ...preState };
-        newState.row[position.rowNum] = row;
         newState.column[position.columnNum] = column;
+        newState.row[position.rowNum] = row;
         if (lower) {
           newState.lower = lower;
         }

--- a/features/bingoLineUtills.test.ts
+++ b/features/bingoLineUtills.test.ts
@@ -53,17 +53,17 @@ describe(detectLine.name, () => {
 });
 
 describe(getLineStatus.name, () => {
-  const { row, column, upper, lower } = getLineStatus(
-    { rowNum: 2, columnNum: 2 },
+  const { column, row, upper, lower } = getLineStatus(
+    { columnNum: 2, rowNum: 2 },
     bingoSheet,
   );
 
   test('列の配列が正常になる。', () => {
-    expect(row).toBe('Bingo');
+    expect(column).toBe('Bingo');
   });
 
   test('行の配列が正常になる。', () => {
-    expect(column).toBe('Initial');
+    expect(row).toBe('Initial');
   });
 
   test('➚の配列が正常になる。', () => {

--- a/features/bingoLineUtills.ts
+++ b/features/bingoLineUtills.ts
@@ -18,34 +18,34 @@ export const detectLine = (line: BingoLine) => {
 };
 
 export const getLineStatus = (
-  { rowNum, columnNum }: BingoElementPosition,
+  { columnNum, rowNum }: BingoElementPosition,
   bingoSheet: BingoSheet,
 ) => {
   const status: {
-    row: LineStatus;
     column: LineStatus;
+    row: LineStatus;
     upper?: LineStatus;
     lower?: LineStatus;
   } = {
-    row: 'Initial',
     column: 'Initial',
+    row: 'Initial',
     upper: undefined,
     lower: undefined,
   };
 
-  status.row = detectLine(bingoSheet[rowNum]);
+  status.column = detectLine(bingoSheet[columnNum]);
 
-  status.column = detectLine(
-    bingoSheet[0]?.map((_, i) => bingoSheet.map((row) => row[i]))[columnNum],
+  status.row = detectLine(
+    bingoSheet[0]?.map((_, i) => bingoSheet.map((column) => column[i]))[rowNum],
   );
 
   if (rowNum === columnNum) {
-    status.lower = detectLine(bingoSheet.map((row, i) => row[i]));
+    status.lower = detectLine(bingoSheet.map((column, i) => column[i]));
   }
 
-  if (rowNum === bingoSheet.length - columnNum - 1) {
+  if (columnNum === bingoSheet.length - rowNum - 1) {
     status.upper = detectLine(
-      bingoSheet.map((row, i) => row[row.length - i - 1]),
+      bingoSheet.map((column, i) => column[column.length - i - 1]),
     );
   }
 

--- a/features/bingoSheetUtills.test.ts
+++ b/features/bingoSheetUtills.test.ts
@@ -1,21 +1,21 @@
-import { getBingoNumberRow } from './bingoSheetUtills';
+import { getBingoNumberColumn } from './bingoSheetUtills';
 
-describe(getBingoNumberRow.name, () => {
+describe(getBingoNumberColumn.name, () => {
   const params = { min: 1, max: 15, length: 15 };
 
   test('列のサイズが指定したものである。', () => {
-    expect(getBingoNumberRow(params).length).toBe(params.length);
+    expect(getBingoNumberColumn(params).length).toBe(params.length);
   });
 
   test('列の値が範囲内である。', () => {
     expect(
-      getBingoNumberRow(params).every(
+      getBingoNumberColumn(params).every(
         (el) => params.min <= el && el <= params.max,
       ),
     ).toBe(true);
   });
 
   test('列の値が重複していない。', () => {
-    expect(new Set(getBingoNumberRow(params)).size).toBe(params.length);
+    expect(new Set(getBingoNumberColumn(params)).size).toBe(params.length);
   });
 });

--- a/features/bingoSheetUtills.ts
+++ b/features/bingoSheetUtills.ts
@@ -1,4 +1,4 @@
-export const getBingoNumberRow = ({
+export const getBingoNumberColumn = ({
   min,
   max,
   length,
@@ -22,13 +22,13 @@ export const getBingoNumberRow = ({
 
 export const getBingoNumber = (length: number) => {
   return Array.from({ length }).map((_, i) =>
-    getBingoNumberRow({ min: i * 15 + 1, max: (i + 1) * 15, length }),
+    getBingoNumberColumn({ min: i * 15 + 1, max: (i + 1) * 15, length }),
   );
 };
 
 export const getInitialBingo = (length: number) => {
-  return getBingoNumber(length).map((row, i) => {
-    return row.map((el, j) => {
+  return getBingoNumber(length).map((column, i) => {
+    return column.map((el, j) => {
       if (i === Math.floor(length / 2) && j === Math.floor(length / 2)) {
         return { num: el, isOpened: true };
       }


### PR DESCRIPTION
## 概要
- rowとcolumnの意味を逆で認識してしまっていたため修正(機能に影響なし)